### PR TITLE
bug: Add get_segm_start method to GDBContextAPI

### DIFF
--- a/plugins/tenet/integration/api/gdb_api.py
+++ b/plugins/tenet/integration/api/gdb_api.py
@@ -135,6 +135,9 @@ class GDBContextAPI:
                 if not page.execute:
                     self.log("[WARNING] Page is not executable")
                 return page.start
+            
+    def get_segm_start(self, ea):
+        return self.get_module_base(ea)
 
     def get_module_base_by_name(self, name):
         pages = self.cache_pages


### PR DESCRIPTION
The `get_segm_start` method is added to the `GDBContextAPI` class in `gdb_api.py`.